### PR TITLE
pin down the aws lb controller chart version to 1.4.5

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -211,6 +211,7 @@ resource "helm_release" "aws_load_balancer_controller" {
   repository = "https://aws.github.io/eks-charts"
   chart      = "aws-load-balancer-controller"
   namespace  = "kube-system"
+  version    = "1.4.5"
 
   set {
     name  = "clusterName"


### PR DESCRIPTION
Update to AWS LB controller chart causes issues for other char's webhooks:
```
Release "karpenter" failed: Internal error occurred: failed calling webhook "mservice.elbv2.k8s.aws": failed to call webhook: the server could not find the requested resource
```