### PR TITLE
external-secrets irsa role

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -323,7 +323,7 @@ module "external_secrets_irsa" {
   oidc_providers = {
     main = {
       provider_arn               = module.eks.oidc_provider_arn
-      namespace_service_accounts = ["kube-system:aws-node"]
+      namespace_service_accounts = ["external-secrets:external-secrets"]
     }
   }
 


### PR DESCRIPTION
What's in:
* external-secrets runs in external-secrets not kube-system
* external-secrets doesn't work with node roles, only with SA