### PR TITLE
fixes istio scheduling

### DIFF
--- a/modules/istio/values/external-gateway.tftpl
+++ b/modules/istio/values/external-gateway.tftpl
@@ -46,4 +46,3 @@ tolerations:
   operator: "Equal"
   value: "truemark-arm64"
   effect: "NoSchedule"
-

--- a/modules/istio/values/external-gateway.tftpl
+++ b/modules/istio/values/external-gateway.tftpl
@@ -39,5 +39,11 @@ autoscaling:
   minReplicas: 1
   maxReplicas: ${external_gateway_scaling_max_replicas}
   targetCPUUtilizationPercentage: ${external_gateway_scaling_target_cpu_utilization}
-
+nodeSelector:
+  karpenter.sh/nodepool: truemark-arm64
+tolerations:
+- key: "karpenter.sh/nodepool"
+  operator: "Equal"
+  value: "truemark-arm64"
+  effect: "NoSchedule"
 

--- a/modules/istio/values/internal-gateway.tftpl
+++ b/modules/istio/values/internal-gateway.tftpl
@@ -41,3 +41,10 @@ autoscaling:
   minReplicas: 1
   maxReplicas: ${internal_gateway_scaling_max_replicas}
   targetCPUUtilizationPercentage: ${internal_gateway_scaling_target_cpu_utilization}
+nodeSelector:
+  karpenter.sh/nodepool: truemark-arm64
+tolerations:
+- key: "karpenter.sh/nodepool"
+  operator: "Equal"
+  value: "truemark-arm64"
+  effect: "NoSchedule"

--- a/modules/istio/values/istiod.tftpl
+++ b/modules/istio/values/istiod.tftpl
@@ -47,3 +47,10 @@ meshConfig:
       "path": "%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%",
       "response_code_details": "%RESPONSE_CODE_DETAILS%"
     }
+nodeSelector:
+  karpenter.sh/nodepool: truemark-arm64
+tolerations:
+- key: "karpenter.sh/nodepool"
+  operator: "Equal"
+  value: "truemark-arm64"
+  effect: "NoSchedule"


### PR DESCRIPTION
- Istio discovery and truemark managed internal/external istio gateway deployments will always go to truemark-arm64
