### PR TITLE
use karpenter namespace for karpenter crd webhook

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -198,7 +198,7 @@ data "http" "karpenter_crds" {
 
 resource "kubectl_manifest" "karpenter_crds" {
   for_each  = data.http.karpenter_crds
-  yaml_body = each.value.body
+  yaml_body = replace(each.value.body, "kube-system", "karpenter")
 }
 
 resource "helm_release" "karpenter" {


### PR DESCRIPTION
The version 0.37.0 had no webhooks. After the introduction of the webhook, the raw manifests for CRDs can't be used. Because the use as namespace kube-system and truemark module is relying on karpenter being deployed to karpenter namespace.
The change is producing on version 0.37.3 diff:
```
resource "kubectl_manifest" "karpenter_crds" {
        id                      = "/apis/apiextensions.k8s.io/v1/customresourcedefinitions/ec2nodeclasses.karpenter.k8s.aws"
        name                    = "ec2nodeclasses.karpenter.k8s.aws"
      ~ yaml_body               = (sensitive value)
      ~ yaml_body_parsed        = <<-EOT
            apiVersion: apiextensions.k8s.io/v1
            kind: CustomResourceDefinition
            metadata:
              annotations:
                controller-gen.kubebuilder.io/version: v0.16.2
              name: ec2nodeclasses.karpenter.k8s.aws
            spec:
              conversion:
                strategy: Webhook
                webhook:
                  clientConfig:
                    service:
                      name: karpenter
          -           namespace: kube-system
          +           namespace: karpenter
```