### PR TITLE
node scalers: karpenter and castai

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -176,67 +176,6 @@ resource "aws_eks_access_policy_association" "access_policy_associations" {
   }
 }
 
-module "karpenter" {
-  count   = var.enable_karpenter ? 1 : 0
-  source  = "terraform-aws-modules/eks/aws//modules/karpenter"
-  version = "~> 20.14"
-
-  cluster_name = module.eks.cluster_name
-  node_iam_role_additional_policies = {
-    AmazonSSMManagedInstanceCore = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
-  }
-  enable_irsa                     = true
-  irsa_oidc_provider_arn          = module.eks.oidc_provider_arn
-  irsa_namespace_service_accounts = ["karpenter:karpenter"]
-
-  tags = var.tags
-}
-
-data "http" "karpenter_crds" {
-  for_each = toset(local.karpenter_crds)
-  url      = "https://raw.githubusercontent.com/aws/karpenter/v${var.karpenter_version}/pkg/apis/crds/${each.key}"
-}
-
-resource "kubectl_manifest" "karpenter_crds" {
-  for_each  = data.http.karpenter_crds
-  yaml_body = replace(each.value.body, "kube-system", "karpenter")
-}
-
-resource "helm_release" "karpenter" {
-  count            = var.enable_karpenter ? 1 : 0
-  namespace        = "karpenter"
-  create_namespace = true
-
-  name                = "karpenter"
-  repository          = "oci://public.ecr.aws/karpenter"
-  repository_username = data.aws_ecrpublic_authorization_token.token[0].user_name
-  repository_password = data.aws_ecrpublic_authorization_token.token[0].password
-  chart               = "karpenter"
-  version             = var.karpenter_version
-
-  values = [
-    <<-EOT
-    settings:
-      clusterName: ${module.eks.cluster_name}
-      clusterEndpoint: ${module.eks.cluster_endpoint}
-      interruptionQueueName: ${module.karpenter[0].queue_name}
-      featureGates:
-        drift: ${var.karpenter_settings_featureGates_drift}
-    podAnnotations:
-      prometheus.io/path: /metrics
-      prometheus.io/port: '8000'
-      prometheus.io/scrape: 'true'
-    nodeSelector:
-      ${jsonencode(var.critical_addons_node_selector)}
-    tolerations:
-      ${jsonencode(var.critical_addons_node_tolerations)}
-    serviceAccount:
-      annotations:
-        eks.amazonaws.com/role-arn: ${module.karpenter[0].iam_role_arn}
-    EOT
-  ]
-}
-
 resource "kubectl_manifest" "karpenter_node_class" {
   count     = var.enable_karpenter ? 1 : 0
   yaml_body = <<-YAML

--- a/modules/cast-ai/main.tf
+++ b/modules/cast-ai/main.tf
@@ -1,0 +1,50 @@
+resource "helm_release" "cast_ai_agent" {
+  count = var.enable_cast_ai_agent ? 1 : 0
+
+  name       = "castai-agent"
+  chart      = "castai-agent"
+  namespace  = "castai-agent"
+  repository = "https://castai.github.io/charts"
+  set {
+    name  = "apiKey"
+    value = var.cast_ai_agent_api_key
+  }
+  set {
+    name  = "provider"
+    value = "eks"
+  }
+}
+
+resource "helm_release" "castai_cluster_controller" {
+  count = var.enable_castai_cluster_controller ? 1 : 0
+
+  name       = "castai-cluster-controller"
+  chart      = "castai-cluster-controller"
+  namespace  = "castai-agent"
+  repository = "https://castai.github.io/charts"
+  set {
+    name  = "apiKey"
+    value = var.cast_ai_agent_api_key
+  }
+  set {
+    name  = "clusterID"
+    value = var.cluster_id
+  }
+}
+
+resource "helm_release" "castai_spot_handler" {
+  count = var.enable_castai_spot_handler ? 1 : 0
+
+  name       = "castai-spot-handler"
+  chart      = "castai-spot-handler"
+  namespace  = "castai-agent"
+  repository = "https://castai.github.io/charts"
+  set {
+    name  = "provider"
+    value = "eks"
+  }
+  set {
+    name  = "clusterID"
+    value = var.cluster_id
+  }
+}

--- a/modules/cast-ai/variables.tf
+++ b/modules/cast-ai/variables.tf
@@ -1,0 +1,24 @@
+variable "enable_cast_ai_agent" {
+  description = "Enable Cast AI agent"
+  type        = bool
+}
+
+variable "cast_ai_agent_api_key" {
+  description = "Cast AI agent API key"
+  type        = string
+}
+
+variable "enable_castai_cluster_controller" {
+  description = "Enable Cast AI cluster controller"
+  type        = bool
+}
+
+variable "cluster_id" {
+  description = "Cast AI cluster ID"
+  type        = string
+}
+
+variable "enable_castai_spot_handler" {
+  description = "Enable Cast AI spot handler"
+  type        = bool
+}

--- a/modules/karpenter/main.tf
+++ b/modules/karpenter/main.tf
@@ -1,0 +1,63 @@
+module "karpenter" {
+  source  = "terraform-aws-modules/eks/aws//modules/karpenter"
+  version = "~> 20.14"
+
+  cluster_name = module.eks.cluster_name
+  node_iam_role_additional_policies = {
+    AmazonSSMManagedInstanceCore = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+  }
+  enable_irsa                     = true
+  irsa_oidc_provider_arn          = module.eks.oidc_provider_arn
+  irsa_namespace_service_accounts = ["karpenter:karpenter"]
+
+  tags = var.tags
+}
+
+resource "helm_release" "karpenter" {
+  namespace        = "karpenter"
+  create_namespace = true
+
+  name                = "karpenter"
+  repository          = "oci://public.ecr.aws/karpenter"
+  repository_username = data.aws_ecrpublic_authorization_token.token[0].user_name
+  repository_password = data.aws_ecrpublic_authorization_token.token[0].password
+  chart               = "karpenter"
+  version             = var.karpenter_controller_version
+  skip_crds           = true
+
+  values = [
+    <<-EOT
+    settings:
+      clusterName: ${module.eks.cluster_name}
+      clusterEndpoint: ${module.eks.cluster_endpoint}
+      interruptionQueueName: ${module.karpenter[0].queue_name}
+      featureGates:
+        drift: ${var.karpenter_settings_featureGates_drift}
+    podAnnotations:
+      prometheus.io/path: /metrics
+      prometheus.io/port: '8000'
+      prometheus.io/scrape: 'true'
+    nodeSelector:
+      ${jsonencode(var.critical_addons_node_selector)}
+    tolerations:
+      ${jsonencode(var.critical_addons_node_tolerations)}
+    serviceAccount:
+      annotations:
+        eks.amazonaws.com/role-arn: ${module.karpenter.iam_role_arn}
+    EOT
+  ]
+}
+
+resource "helm_release" "karpenter_crds" {
+  namespace           = "karpenter"
+  name                = "karpenter-crds"
+  repository          = "oci://public.ecr.aws/karpenter"
+  chart               = "karpenter-crds"
+  repository_username = data.aws_ecrpublic_authorization_token.token[0].user_name
+  repository_password = data.aws_ecrpublic_authorization_token.token[0].password
+  version             = var.karpenter_crds_version
+
+  depends_on = [
+    helm_release.karpenter
+  ]
+}

--- a/modules/karpenter/outputs.tf
+++ b/modules/karpenter/outputs.tf
@@ -1,0 +1,3 @@
+output "karpenter_node_iam_role_arn" {
+  value = module.karpenter.node_iam_role_name
+}

--- a/modules/karpenter/variables.tf
+++ b/modules/karpenter/variables.tf
@@ -1,0 +1,29 @@
+variable "karpenter_controller_version" {
+  description = "Version of karpenter controller to install"
+  type        = string
+}
+
+variable "karpenter_crds_version" {
+  description = "Version of karpenter's CRDs to install"
+  type        = string
+}
+
+variable "karpenter_settings_featureGates_drift" {
+  type        = bool
+  description = "Enable or disable drift feature of karpenter"
+}
+
+variable "critical_addons_node_selector" {
+  description = "Config for node selector for workloads"
+  type        = map(any)
+}
+
+variable "critical_addons_node_tolerations" {
+  description = "Config for node tolerations for workloads"
+  type        = list(any)
+}
+
+variable "tags" {
+  description = "A map of tags to add to all resources."
+  type        = map(string)
+}

--- a/modules/karpenter/variables.tf
+++ b/modules/karpenter/variables.tf
@@ -8,6 +8,16 @@ variable "karpenter_crds_version" {
   type        = string
 }
 
+variable "enable_karpenter_controller_webhook" {
+  description = "Enable or disable karpenter controller webhook"
+  type        = bool
+}
+
+variable "enable_karpenter_crd_webhook" {
+  description = "Enable or disable karpenter CRD webhook"
+  type        = bool
+}
+
 variable "karpenter_settings_featureGates_drift" {
   type        = bool
   description = "Enable or disable drift feature of karpenter"
@@ -26,4 +36,29 @@ variable "critical_addons_node_tolerations" {
 variable "tags" {
   description = "A map of tags to add to all resources."
   type        = map(string)
+}
+
+variable "cluster_name" {
+  description = "Name of the EKS cluster"
+  type        = string
+}
+
+variable "oidc_provider_arn" {
+  description = "OIDC provider ARN"
+  type        = string
+}
+
+variable "cluster_endpoint" {
+  description = "EKS cluster endpoint"
+  type        = string
+}
+
+variable "aws_ecrpublic_authorization_token_user_name" {
+  description = "ECR public authorization token user_name"
+  type        = string
+}
+
+variable "aws_ecrpublic_authorization_token_user_password" {
+  description = "ECR public authorization token password"
+  type        = string
 }

--- a/move.tf
+++ b/move.tf
@@ -1,9 +1,4 @@
 moved {
-  from = helm_release.karpenter
-  to   = helm_release.karpenter[0]
-}
-
-moved {
   from = kubectl_manifest.karpenter_node_class
   to   = kubectl_manifest.karpenter_node_class[0]
 }
@@ -15,4 +10,103 @@ moved {
 moved {
   from = kubectl_manifest.karpenter_node_pool_amd
   to   = kubectl_manifest.karpenter_node_pool_amd[0]
+}
+
+moved {
+  from = helm_release.karpenter[0]
+  to   = module.karpenter[0].helm_release.karpenter
+}
+moved {
+  from = module.karpenter[0].aws_cloudwatch_event_rule.this["health_event"]
+  to   = module.karpenter[0].module.karpenter.aws_cloudwatch_event_rule.this["health_event"]
+}
+
+moved {
+  from = module.karpenter[0].aws_cloudwatch_event_target.this["health_event"]
+  to   = module.karpenter[0].module.karpenter.aws_cloudwatch_event_target.this["health_event"]
+}
+
+moved {
+  from = module.karpenter[0].aws_iam_role_policy_attachment.controller[0]
+  to   = module.karpenter[0].module.karpenter.aws_iam_role_policy_attachment.controller[0]
+}
+
+moved {
+  from = module.karpenter[0].aws_sqs_queue.this[0]
+  to   = module.karpenter[0].module.karpenter.aws_sqs_queue.this[0]
+}
+
+moved {
+  from = module.karpenter[0].aws_iam_role_policy_attachment.node["AmazonEC2ContainerRegistryReadOnly"]
+  to   = module.karpenter[0].module.karpenter.aws_iam_role_policy_attachment.node["arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"]
+}
+
+moved {
+  from = module.karpenter[0].aws_iam_role_policy_attachment.node["AmazonEKSWorkerNodePolicy"]
+  to   = module.karpenter[0].module.karpenter.aws_iam_role_policy_attachment.node["arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"]
+}
+
+moved {
+  from = module.karpenter[0].aws_iam_role_policy_attachment.node["AmazonEKS_CNI_Policy"]
+  to   = module.karpenter[0].module.karpenter.aws_iam_role_policy_attachment.node["arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"]
+}
+
+moved {
+  from = module.karpenter[0].aws_iam_role_policy_attachment.node_additional["AmazonSSMManagedInstanceCore"]
+  to   = module.karpenter[0].module.karpenter.aws_iam_role_policy_attachment.node_additional["AmazonSSMManagedInstanceCore"]
+}
+
+moved {
+  from = module.karpenter[0].aws_iam_policy.controller[0]
+  to   = module.karpenter[0].module.karpenter.aws_iam_policy.controller[0]
+}
+
+moved {
+  from = module.karpenter[0].aws_eks_access_entry.node[0]
+  to   = module.karpenter[0].module.karpenter.aws_eks_access_entry.node[0]
+}
+
+moved {
+  from = module.karpenter[0].aws_sqs_queue_policy.this[0]
+  to   = module.karpenter[0].module.karpenter.aws_sqs_queue_policy.this[0]
+}
+
+moved {
+  from = module.karpenter[0].aws_iam_role.node[0]
+  to   = module.karpenter[0].module.karpenter.aws_iam_role.node[0]
+}
+
+moved {
+  from = module.karpenter[0].aws_cloudwatch_event_rule.this["instance_state_change"]
+  to   = module.karpenter[0].module.karpenter.aws_cloudwatch_event_rule.this["instance_state_change"]
+}
+
+moved {
+  from = module.karpenter[0].aws_cloudwatch_event_rule.this["instance_rebalance"]
+  to   = module.karpenter[0].module.karpenter.aws_cloudwatch_event_rule.this["instance_rebalance"]
+}
+
+moved {
+  from = module.karpenter[0].aws_iam_role.controller[0]
+  to   = module.karpenter[0].module.karpenter.aws_iam_role.controller[0]
+}
+
+moved {
+  from = module.karpenter[0].aws_cloudwatch_event_rule.this["spot_interrupt"]
+  to   = module.karpenter[0].module.karpenter.aws_cloudwatch_event_rule.this["spot_interupt"]
+}
+
+moved {
+  from = module.karpenter[0].aws_cloudwatch_event_target.this["spot_interrupt"]
+  to   = module.karpenter[0].module.karpenter.aws_cloudwatch_event_target.this["spot_interupt"]
+}
+
+moved {
+  from = module.karpenter[0].aws_cloudwatch_event_target.this["instance_rebalance"]
+  to   = module.karpenter[0].module.karpenter.aws_cloudwatch_event_target.this["instance_rebalance"]
+}
+
+moved {
+  from = module.karpenter[0].aws_cloudwatch_event_target.this["instance_state_change"]
+  to   = module.karpenter[0].module.karpenter.aws_cloudwatch_event_target.this["instance_state_change"]
 }

--- a/node_class.tf
+++ b/node_class.tf
@@ -1,0 +1,26 @@
+resource "kubectl_manifest" "karpenter_node_class" {
+  count     = var.enable_karpenter ? 1 : 0
+  yaml_body = <<-YAML
+    apiVersion: karpenter.k8s.aws/v1beta1
+    kind: EC2NodeClass
+    metadata:
+      name: truemark
+    spec:
+      amiFamily: ${var.truemark_nodeclass_default_ami_family}
+      blockDeviceMappings: ${jsonencode(var.truemark_nodeclass_default_block_device_mappings.specs)}
+      role: ${module.karpenter[0].karpenter_node_iam_role_arn}
+      subnetSelectorTerms:
+        - tags:
+            ${jsonencode(var.karpenter_node_template_default.subnetSelector)}
+      securityGroupSelectorTerms:
+        - tags:
+            karpenter.sh/discovery: ${module.eks.cluster_name}
+      tags:
+        Name: "${module.eks.cluster_name}-truemark-default"
+        karpenter.sh/discovery: ${module.eks.cluster_name}
+  YAML
+
+  depends_on = [
+    module.karpenter[0]
+  ]
+}

--- a/node_pools.tf
+++ b/node_pools.tf
@@ -1,43 +1,26 @@
-resource "kubectl_manifest" "karpenter_node_class" {
-  yaml_body = <<-YAML
-    apiVersion: karpenter.k8s.aws/v1beta1
-    kind: EC2NodeClass
-    metadata:
-      name: default
-    spec:
-      amiFamily: ${var.karpenter_provisioner_default_ami_family}
-      blockDeviceMappings: ${jsonencode(var.karpenter_provisioner_default_block_device_mappings.specs)}
-      role: ${module.karpenter[0].node_iam_role_name}
-      subnetSelectorTerms:
-        - tags:
-            ${jsonencode(var.karpenter_node_template_default.subnetSelector)}
-      securityGroupSelectorTerms:
-        - tags:
-            karpenter.sh/discovery: ${module.eks.cluster_name}
-      tags:
-        Name: "${module.eks.cluster_name}-default"
-        karpenter.sh/discovery: ${module.eks.cluster_name}
-  YAML
-
-  depends_on = [
-    helm_release.karpenter
-  ]
-}
 
 resource "kubectl_manifest" "karpenter_node_pool_arm" {
+  count     = var.enable_karpenter ? 1 : 0
   yaml_body = <<-YAML
     apiVersion: karpenter.sh/v1beta1
     kind: NodePool
     metadata:
-      name: default-arm
+      name: truemark-arm64
     spec:
+      disruption:
+        budgets:
+          - nodes: 10%
+        consolidationPolicy: WhenUnderutilized
+        expireAfter: 720h
       template:
         spec:
           nodeClassRef:
-            name: default
+            name: truemark
+          taints:
+          - key: karpenter.sh/nodepool
+            value: "truemark-arm64"
+            effect: NoSchedule
           requirements: ${jsonencode(var.karpenter_node_pool_default_arm_requirements.requirements)}
-      limits:
-        cpu: ${var.karpenter_nodepool_default_cpu_limits}
       disruption:
         expireAfter: ${var.karpenter_nodepool_default_expireAfter}
         consolidationPolicy: WhenEmpty
@@ -51,19 +34,27 @@ resource "kubectl_manifest" "karpenter_node_pool_arm" {
 }
 
 resource "kubectl_manifest" "karpenter_node_pool_amd" {
+  count     = var.enable_karpenter ? 1 : 0
   yaml_body = <<-YAML
     apiVersion: karpenter.sh/v1beta1
     kind: NodePool
     metadata:
-      name: default-amd
+      name: truemark-amd64
     spec:
+      disruption:
+        budgets:
+          - nodes: 10%
+        consolidationPolicy: WhenUnderutilized
+        expireAfter: 720h
       template:
         spec:
           nodeClassRef:
-            name: default
+            name: truemark
+          taints:
+          - key: karpenter.sh/nodepool
+            value: "truemark-amd64"
+            effect: NoSchedule
           requirements: ${jsonencode(var.karpenter_node_pool_default_amd_requirements.requirements)}
-      limits:
-        cpu: ${var.karpenter_nodepool_default_cpu_limits}
       disruption:
         expireAfter: ${var.karpenter_nodepool_default_expireAfter}
         consolidationPolicy: WhenEmpty

--- a/node_pools.tf
+++ b/node_pools.tf
@@ -1,0 +1,77 @@
+resource "kubectl_manifest" "karpenter_node_class" {
+  yaml_body = <<-YAML
+    apiVersion: karpenter.k8s.aws/v1beta1
+    kind: EC2NodeClass
+    metadata:
+      name: default
+    spec:
+      amiFamily: ${var.karpenter_provisioner_default_ami_family}
+      blockDeviceMappings: ${jsonencode(var.karpenter_provisioner_default_block_device_mappings.specs)}
+      role: ${module.karpenter[0].node_iam_role_name}
+      subnetSelectorTerms:
+        - tags:
+            ${jsonencode(var.karpenter_node_template_default.subnetSelector)}
+      securityGroupSelectorTerms:
+        - tags:
+            karpenter.sh/discovery: ${module.eks.cluster_name}
+      tags:
+        Name: "${module.eks.cluster_name}-default"
+        karpenter.sh/discovery: ${module.eks.cluster_name}
+  YAML
+
+  depends_on = [
+    helm_release.karpenter
+  ]
+}
+
+resource "kubectl_manifest" "karpenter_node_pool_arm" {
+  yaml_body = <<-YAML
+    apiVersion: karpenter.sh/v1beta1
+    kind: NodePool
+    metadata:
+      name: default-arm
+    spec:
+      template:
+        spec:
+          nodeClassRef:
+            name: default
+          requirements: ${jsonencode(var.karpenter_node_pool_default_arm_requirements.requirements)}
+      limits:
+        cpu: ${var.karpenter_nodepool_default_cpu_limits}
+      disruption:
+        expireAfter: ${var.karpenter_nodepool_default_expireAfter}
+        consolidationPolicy: WhenEmpty
+        consolidateAfter: 30s
+      weight: ${var.karpenter_arm_node_pool_weight}
+  YAML
+
+  depends_on = [
+    kubectl_manifest.karpenter_node_class
+  ]
+}
+
+resource "kubectl_manifest" "karpenter_node_pool_amd" {
+  yaml_body = <<-YAML
+    apiVersion: karpenter.sh/v1beta1
+    kind: NodePool
+    metadata:
+      name: default-amd
+    spec:
+      template:
+        spec:
+          nodeClassRef:
+            name: default
+          requirements: ${jsonencode(var.karpenter_node_pool_default_amd_requirements.requirements)}
+      limits:
+        cpu: ${var.karpenter_nodepool_default_cpu_limits}
+      disruption:
+        expireAfter: ${var.karpenter_nodepool_default_expireAfter}
+        consolidationPolicy: WhenEmpty
+        consolidateAfter: 30s
+      weight: ${var.karpenter_amd_node_pool_weight}
+  YAML
+
+  depends_on = [
+    kubectl_manifest.karpenter_node_class
+  ]
+}

--- a/scalers.tf
+++ b/scalers.tf
@@ -1,0 +1,23 @@
+module "karpenter" {
+  source = "./modules/karpenter"
+
+  count = var.enable_karpenter ? 1 : 0
+
+  karpenter_controller_version          = var.karpenter_controller_version
+  karpenter_crds_version                = var.karpenter_crds_version
+  karpenter_settings_featureGates_drift = var.karpenter_settings_featureGates_drift
+  critical_addons_node_selector         = var.critical_addons_node_selector
+  critical_addons_node_tolerations      = var.critical_addons_node_tolerations
+  tags                                  = var.tags
+}
+
+module "castai" {
+  source = "./modules/cast-ai"
+
+  enable_cast_ai_agent             = var.enable_cast_ai_agent
+  enable_castai_cluster_controller = var.enable_castai_cluster_controller
+  enable_castai_spot_handler       = var.enable_castai_spot_handler
+
+  cast_ai_agent_api_key = var.cast_ai_agent_api_key
+  cluster_id            = module.eks.cluster_id
+}

--- a/scalers.tf
+++ b/scalers.tf
@@ -3,12 +3,19 @@ module "karpenter" {
 
   count = var.enable_karpenter ? 1 : 0
 
-  karpenter_controller_version          = var.karpenter_controller_version
-  karpenter_crds_version                = var.karpenter_crds_version
-  karpenter_settings_featureGates_drift = var.karpenter_settings_featureGates_drift
-  critical_addons_node_selector         = var.critical_addons_node_selector
-  critical_addons_node_tolerations      = var.critical_addons_node_tolerations
-  tags                                  = var.tags
+  cluster_name                                    = var.cluster_name
+  oidc_provider_arn                               = module.eks.oidc_provider_arn
+  cluster_endpoint                                = module.eks.cluster_endpoint
+  aws_ecrpublic_authorization_token_user_name     = data.aws_ecrpublic_authorization_token.token[0].user_name
+  aws_ecrpublic_authorization_token_user_password = data.aws_ecrpublic_authorization_token.token[0].password
+  karpenter_controller_version                    = var.karpenter_controller_version
+  karpenter_crds_version                          = var.karpenter_crds_version
+  enable_karpenter_controller_webhook             = var.enable_karpenter_controller_webhook
+  enable_karpenter_crd_webhook                    = var.enable_karpenter_crd_webhook
+  karpenter_settings_featureGates_drift           = var.karpenter_settings_featureGates_drift
+  critical_addons_node_selector                   = var.critical_addons_node_selector
+  critical_addons_node_tolerations                = var.critical_addons_node_tolerations
+  tags                                            = var.tags
 }
 
 module "castai" {

--- a/variables.tf
+++ b/variables.tf
@@ -203,7 +203,13 @@ variable "enable_karpenter" {
   default     = true
 }
 
-variable "karpenter_version" {
+variable "karpenter_controller_version" {
+  description = "Version of karpenter to install"
+  type        = string
+  default     = "0.37.0"
+}
+
+variable "karpenter_crds_version" {
   description = "Version of karpenter to install"
   type        = string
   default     = "0.37.0"
@@ -657,6 +663,33 @@ variable "vpa_enabled" {
 
 variable "goldilocks_enabled" {
   description = "Enable Goldilocks operator"
+  type        = bool
+  default     = false
+}
+
+###############################################
+# Cast AI Configuration
+###############################################
+variable "cast_ai_agent_api_key" {
+  description = "Cast AI agent API key"
+  type        = string
+  default     = ""
+}
+
+variable "enable_castai_spot_handler" {
+  description = "Enable Cast AI spot handler"
+  type        = bool
+  default     = false
+}
+
+variable "enable_cast_ai_agent" {
+  description = "Enable Cast AI agent"
+  type        = bool
+  default     = false
+}
+
+variable "enable_castai_cluster_controller" {
+  description = "Enable Cast AI cluster controller"
   type        = bool
   default     = false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -693,3 +693,15 @@ variable "enable_castai_cluster_controller" {
   type        = bool
   default     = false
 }
+
+variable "enable_karpenter_controller_webhook" {
+  description = "Enable or disable karpenter controller webhook"
+  type        = bool
+  default     = false
+}
+
+variable "enable_karpenter_crd_webhook" {
+  description = "Enable or disable karpenter CRD webhook"
+  type        = bool
+  default     = false
+}

--- a/version.txt
+++ b/version.txt
@@ -1,3 +1,3 @@
 # The following contains the next version that will be released when a merge to main occurs
 version=v1.1.14
-next_version=v1.1.15
+next_version=v2.0.0


### PR DESCRIPTION
Add to required providers if it's not added:
```
    http = {
      source  = "hashicorp/http"
      version = "~> 1.2.0"
    }
```
Needed to be removed from the state file
```
module.eks.kubectl_manifest.karpenter_crds["karpenter.k8s.aws_ec2nodeclasses.yaml"]
module.eks.kubectl_manifest.karpenter_crds["karpenter.sh_nodeclaims.yaml"]
module.eks.kubectl_manifest.karpenter_crds["karpenter.sh_nodepools.yaml"] 
```
After the diff will be 
```Plan: 1 to add, 1 to change```
The Karpenter CRDs will be deployed as a separate helm chart and the controller chart will not manage CRDs anymore.

```
kubectl patch crd ec2nodeclasses.karpenter.k8s.aws -p '{"metadata": {"labels": {"app.kubernetes.io/managed-by": "Helm", "meta.helm.sh/release-name": "karpenter-crd", "meta.helm.sh/release-namespace": "karpenter"}}}'
kubectl annotate crd ec2nodeclasses.karpenter.k8s.aws meta.helm.sh/release-name=karpenter-crd meta.helm.sh/release-namespace=karpenter 
```
```
kubectl patch crd nodeclaims.karpenter.sh -p '{"metadata": {"labels": {"app.kubernetes.io/managed-by": "Helm", "meta.helm.sh/release-name": "karpenter-crd", "meta.helm.sh/release-namespace": "karpenter"}}}'
kubectl annotate crd nodeclaims.karpenter.sh meta.helm.sh/release-name=karpenter-crd meta.helm.sh/release-namespace=karpenter
```
```
kubectl patch crd nodepools.karpenter.sh -p '{"metadata": {"labels": {"app.kubernetes.io/managed-by": "Helm", "meta.helm.sh/release-name": "karpenter-crd", "meta.helm.sh/release-namespace": "karpenter"}}}'
kubectl annotate crd nodepools.karpenter.sh meta.helm.sh/release-name=karpenter-crd meta.helm.sh/release-namespace=karpenter
```
After migration to the separate helm chart to manage karpenter crds is possible to migrate to karpenter v1.*.*. Follow https://karpenter.sh/v1.0/upgrading/v1-migration/#upgrade-procedure using variable 
```
enable_karpenter_controller_webhook
enable_karpenter_crd_webhook
karpenter_controller_version
karpenter_crds_version
```